### PR TITLE
fix out_path bug

### DIFF
--- a/paddleapex/apex/run_paddle.py
+++ b/paddleapex/apex/run_paddle.py
@@ -550,6 +550,9 @@ if __name__ == "__main__":
     arg_parser(parser)
     cfg = parser.parse_args()
     forward_content = api_json_read(cfg.json_path)
+    if os.path.realpath(cfg.out_path) == os.path.realpath("./"):
+        cfg.out_path = "./paddle/"
+        print_warn_log("The output path is replaced with \"./paddle\" . Please do not use the current directory as the output directory.")
     out_path = os.path.realpath(cfg.out_path) if cfg.out_path else "./"
     if os.path.exists(out_path):
         shutil.rmtree(out_path)

--- a/paddleapex/apex/run_paddle.py
+++ b/paddleapex/apex/run_paddle.py
@@ -550,12 +550,9 @@ if __name__ == "__main__":
     arg_parser(parser)
     cfg = parser.parse_args()
     forward_content = api_json_read(cfg.json_path)
-    if os.path.realpath(cfg.out_path) == os.path.realpath("./"):
-        cfg.out_path = "./paddle/"
-        print_warn_log("The output path is replaced with \"./paddle\" . Please do not use the current directory as the output directory.")
     out_path = os.path.realpath(cfg.out_path) if cfg.out_path else "./"
     if os.path.exists(out_path):
-        shutil.rmtree(out_path)
+        print_warn_log("The output path already exists and the file with the same name will be overwritten.")
     ut_case_parsing(forward_content, cfg)
     print_info_log("UT save completed")
     warning_log_pth = os.path.join(out_path, "./warning_log.txt")

--- a/paddleapex/apex/run_torch.py
+++ b/paddleapex/apex/run_torch.py
@@ -596,7 +596,7 @@ def arg_parser(parser):
         "-out",
         "--dump_path",
         dest="out_path",
-        default="./paddle/",
+        default="./torch/",
         type=str,
         help="<optional> The ut task result out path.",
         required=False,
@@ -643,6 +643,9 @@ if __name__ == "__main__":
     arg_parser(parser)
     cfg = parser.parse_args()
     forward_content = api_json_read(cfg.json_path)
+    if os.path.realpath(cfg.out_path) == os.path.realpath("./"):
+        cfg.out_path = "./torch/"
+        print_warn_log("The output path is replaced with \"./torch\" . Please do not use the current directory as the output directory.")
     out_path = os.path.realpath(cfg.out_path) if cfg.out_path else "./"
     if os.path.exists(out_path):
         shutil.rmtree(out_path)

--- a/paddleapex/apex/run_torch.py
+++ b/paddleapex/apex/run_torch.py
@@ -643,12 +643,9 @@ if __name__ == "__main__":
     arg_parser(parser)
     cfg = parser.parse_args()
     forward_content = api_json_read(cfg.json_path)
-    if os.path.realpath(cfg.out_path) == os.path.realpath("./"):
-        cfg.out_path = "./torch/"
-        print_warn_log("The output path is replaced with \"./torch\" . Please do not use the current directory as the output directory.")
     out_path = os.path.realpath(cfg.out_path) if cfg.out_path else "./"
     if os.path.exists(out_path):
-        shutil.rmtree(out_path)
+        print_warn_log("The output path already exists and the file with the same name will be overwritten.")
     ut_case_parsing(forward_content, cfg)
     print_info_log("UT save completed")
     warning_log_pth = os.path.join(out_path, "./warning_log.txt")


### PR DESCRIPTION
修复跑单测时设置当前目录为输出路径导致当前目录被删除的问题。若执行时设置为当前目录，则改为默认输出路径。