### PR TITLE
support split dump_info when saving json files

### DIFF
--- a/paddleapex/apex/run_paddle.py
+++ b/paddleapex/apex/run_paddle.py
@@ -106,7 +106,7 @@ def convert_out2fp32(arg_in):
             flag = flag or ret_flag
         return flag, res
     elif isinstance(arg_in, paddle.Tensor):
-        if arg_in.dtype.name == "BF16":
+        if arg_in.dtype.name == "BF16" or arg_in.dtype.name == "BFLOAT16":
             arg_in = arg_in.cast("float32")
             flag = True
         return flag, arg_in

--- a/paddleapex/api_tracer/Dump.py
+++ b/paddleapex/api_tracer/Dump.py
@@ -23,12 +23,11 @@ def create_directory(data_route):
     except OSError as ex:
         print("In create_directory: for dump_path:{}, {}".format(data_route, str(ex)))
 
-
-def write_json(file_path, data, rank=None, mode="forward"):
+def write_json(file_path, data, rank=None, mode="forward", split_type="all"):
     if rank is not None:
-        json_pth = os.path.join(file_path, mode + "_rank" + str(rank) + ".json")
+        json_pth = os.path.join(file_path, mode + "_rank" + str(rank) + "_" + split_type + ".json")
     else:
-        json_pth = os.path.join(file_path, mode + ".json")
+        json_pth = os.path.join(file_path, mode + "_" + split_type + ".json")
     if os.path.exists(json_pth):
         os.remove(json_pth)
         print(f"File {json_pth} already exists, tool has overwritten it automatically.")
@@ -67,6 +66,8 @@ class Dump:
         self.mode = mode
         self.rank = None
         self.dump_api_dict = None
+        self.dump_api_dict_half = None
+        self.dump_api_dict_other = None
         self.Async_save = Async_save
 
         if self.Async_save:
@@ -103,12 +104,24 @@ class Dump:
         Get Api_info dict, update self.dump_api_dict
     """
 
-    def update_api_dict(self, api_info_dict, rank):
+    def update_api_dict(self, api_info_dict, rank, is_half_precision = False):
         self.rank = rank
         if self.dump_api_dict is None:
-            self.dump_api_dict = api_info_dict
+            self.dump_api_dict = api_info_dict.copy()
         else:
             self.dump_api_dict.update(api_info_dict)
+        
+        if cfg.split_dump:
+            if is_half_precision:
+                if self.dump_api_dict_half is None:
+                    self.dump_api_dict_half = api_info_dict.copy()
+                else:
+                    self.dump_api_dict_half.update(api_info_dict)
+            else:
+                if self.dump_api_dict_other is None:
+                    self.dump_api_dict_other = api_info_dict.copy()
+                else:
+                    self.dump_api_dict_other.update(api_info_dict)
 
     def dump(self):
         if self.rank is not None:
@@ -126,9 +139,15 @@ class Dump:
             self.dump_api_dict = get_unique_api_dict(self.dump_api_dict)
         create_directory(directory)
         if self.rank is not None:
-            write_json(directory, self.dump_api_dict, rank=self.rank, mode="forward")
+            write_json(directory, self.dump_api_dict, rank=self.rank, mode="forward", split_type="all")
+            if cfg.split_dump:
+                write_json(directory, self.dump_api_dict_half, rank=self.rank, mode="forward", split_type="half")
+                write_json(directory, self.dump_api_dict_other, rank=self.rank, mode="forward", split_type="other")
         else:
-            write_json(directory, self.dump_api_dict, rank=None, mode="forward")
+            write_json(directory, self.dump_api_dict, rank=None, mode="forward", split_type="all")
+            if cfg.split_dump:
+                write_json(directory, self.dump_api_dict_half, rank=None, mode="forward", split_type="half")
+                write_json(directory, self.dump_api_dict_other, rank=None, mode="forward", split_type="other")
 
 
 dump_util = Dump()

--- a/paddleapex/api_tracer/Dump.py
+++ b/paddleapex/api_tracer/Dump.py
@@ -137,6 +137,9 @@ class Dump:
             print("Especially in pipeline parallel mode!")
         if cfg.dump_unique:
             self.dump_api_dict = get_unique_api_dict(self.dump_api_dict)
+            if cfg.split_dump:
+                self.dump_api_dict_half = get_unique_api_dict(self.dump_api_dict_half)
+                self.dump_api_dict_other = get_unique_api_dict(self.dump_api_dict_other)
         create_directory(directory)
         if self.rank is not None:
             write_json(directory, self.dump_api_dict, rank=self.rank, mode="forward", split_type="all")

--- a/paddleapex/api_tracer/config.py
+++ b/paddleapex/api_tracer/config.py
@@ -34,6 +34,7 @@ class Config:
             self.Async_dump = configs["Async_dump"]
             self.profile_mode = configs["profile_mode"]
             self.dump_unique = configs["dump_unique"]
+            self.split_dump = configs["split_dump"]
             f.close()
         print("*" * 100)
         print(f"You are using Apex Toolkit, Dump mode : {self.dump_mode}, Target step : {self.target_step}, profile mode : {self.profile_mode}")

--- a/paddleapex/api_tracer/configs/tool_config.yaml
+++ b/paddleapex/api_tracer/configs/tool_config.yaml
@@ -21,3 +21,6 @@ target_step: [0]
 
 # Remove duplicate apis from dump_info and keep only one api in the same value range.
 dump_unique: True
+
+# Split dump_info into half-precision operators and other operators when saving json files
+split_dump: True


### PR DESCRIPTION
支持在dump info时保存三种json文件：1. 抓取的所有算子；2. 输入涉及半精度的算子；3. 除半精度算子外的其他算子 。