### PR TITLE
optimize op_record to reduce missed ops

### DIFF
--- a/paddleapex/api_tracer/api_info.py
+++ b/paddleapex/api_tracer/api_info.py
@@ -112,20 +112,17 @@ class API:
         args_info_list = self.analyze_element(inputs)
         kwargs_info_dict = self.analyze_element(kwargs)
         self.api_info_struct = {
-            self.op_name: {"args": args_info_list, "kwargs": kwargs_info_dict}
+            self.op_name: {"args": args_info_list, "kwargs": kwargs_info_dict, "dout_list": ["Failed"]}
         }
+        dump_util.update_api_dict(self.api_info_struct, self.rank, self.is_half_precision)
 
     def record_dout(self, grad_value):
-        if grad_value is None:
-            self.api_info_struct[self.op_name].update({"dout_list": ["Failed"]})
-            dump_util.update_api_dict(self.api_info_struct, self.rank, self.is_half_precision)
-        else:
+        if grad_value is not None:
             dout = self.analyze_element(grad_value)
             self.dout_list.append(dout)
             self.output_num -= 1
             if self.output_num == 0:
                 self.api_info_struct[self.op_name].update({"dout_list": self.dout_list})
-                dump_util.update_api_dict(self.api_info_struct, self.rank, self.is_half_precision)
 
     def analyze_element(self, element):
         if isinstance(element, (list, tuple)):


### PR DESCRIPTION
更新算子字典的逻辑放到前向计算，反向只需要更新dout信息。目的是让前向计算的算子都可以被抓取，尽量减少算子的遗漏。